### PR TITLE
Switched badge to concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Summary
-[![Build Status](https://loggregator.ci.cf-app.com/api/v1/teams/main/pipelines/nozzles/jobs/datadog-nozzle-unit-tests/badge)](https://loggregator.ci.cf-app.com/teams/main/pipelines/nozzles/jobs/datadog-nozzle-unit-tests) [![Coverage Status](https://coveralls.io/repos/cloudfoundry-incubator/datadog-firehose-nozzle/badge.svg)](https://coveralls.io/r/cloudfoundry-incubator/datadog-firehose-nozzle)
+[![Build Status](http://crossorigin.me/https://loggregator.ci.cf-app.com/api/v1/teams/main/pipelines/nozzles/jobs/datadog-nozzle-unit-tests/badge)](https://loggregator.ci.cf-app.com/teams/main/pipelines/nozzles/jobs/datadog-nozzle-unit-tests) [![Coverage Status](https://coveralls.io/repos/cloudfoundry-incubator/datadog-firehose-nozzle/badge.svg)](https://coveralls.io/r/cloudfoundry-incubator/datadog-firehose-nozzle)
 
 The datadog-firehose-nozzle is a CF component which forwards metrics from the Loggregator Firehose to [Datadog](http://www.datadoghq.com/)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Summary
-[![Build Status](https://travis-ci.org/cloudfoundry-incubator/datadog-firehose-nozzle.svg?branch=master)](https://travis-ci.org/cloudfoundry-incubator/datadog-firehose-nozzle) [![Coverage Status](https://coveralls.io/repos/cloudfoundry-incubator/datadog-firehose-nozzle/badge.svg)](https://coveralls.io/r/cloudfoundry-incubator/datadog-firehose-nozzle)
+[![Build Status](https://loggregator.ci.cf-app.com/api/v1/teams/main/pipelines/nozzles/jobs/datadog-nozzle-unit-tests/badge)](https://loggregator.ci.cf-app.com/teams/main/pipelines/nozzles/jobs/datadog-nozzle-unit-tests) [![Coverage Status](https://coveralls.io/repos/cloudfoundry-incubator/datadog-firehose-nozzle/badge.svg)](https://coveralls.io/r/cloudfoundry-incubator/datadog-firehose-nozzle)
 
 The datadog-firehose-nozzle is a CF component which forwards metrics from the Loggregator Firehose to [Datadog](http://www.datadoghq.com/)
 


### PR DESCRIPTION
According to the [Concourse documentation](http://engineering.pivotal.io/post/concourse-badges/) this fixes #13 but I swear the image won't load for me. The raw badge is located ![here](https://loggregator.ci.cf-app.com/api/v1/pipelines/nozzles/jobs/datadog-nozzle-unit-tests/badge) which also breaks in this comment so I can only think there's some reason github doesn't like the image URL without a .svg at the end.
I'm going to open an issue for concourse since I saw other projects with broken badge images too.