### PR TITLE
Add support for metron error event envelopes

### DIFF
--- a/datadogclient/datadog_client.go
+++ b/datadogclient/datadog_client.go
@@ -22,6 +22,7 @@ type Client struct {
 	apiURL                string
 	apiKey                string
 	metricPoints          map[MetricKey]MetricValue
+	events                []Event
 	prefix                string
 	deployment            string
 	ip                    string
@@ -55,6 +56,18 @@ type Metric struct {
 	Type   string   `json:"type"`
 	Host   string   `json:"host,omitempty"`
 	Tags   []string `json:"tags,omitempty"`
+}
+
+type Event struct {
+	Title          string   `json:"title"`
+	Text           string   `json:"text"`
+	DateHappened   int64    `json:"date_happened,omitempty"`
+	Host           string   `json:"host,omitempty"`
+	Priority       string   `json:"priority,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	AlertType      string   `json:"alert_type,omitempty"`
+	AggregationKey string   `json:"aggregation_key,omitempty"`
+	SourceTypeName string   `json:"source_type_name,omitempty"`
 }
 
 type Point struct {
@@ -100,12 +113,20 @@ func (c *Client) AlertSlowConsumerError() {
 	c.addInternalMetric("slowConsumerAlert", uint64(1))
 }
 
-func (c *Client) AddMetric(envelope *events.Envelope) {
+func (c *Client) Add(envelope *events.Envelope) {
 	c.totalMessagesReceived++
-	if envelope.GetEventType() != events.Envelope_ValueMetric && envelope.GetEventType() != events.Envelope_CounterEvent {
+
+	switch envelope.GetEventType() {
+	case events.Envelope_CounterEvent, events.Envelope_ValueMetric:
+		c.addMetric(envelope)
+	case events.Envelope_Error:
+		c.addEvent(envelope)
+	default:
 		return
 	}
+}
 
+func (c *Client) addMetric(envelope *events.Envelope) {
 	tags := parseTags(envelope)
 	key := MetricKey{
 		EventType: envelope.GetEventType(),
@@ -125,22 +146,54 @@ func (c *Client) AddMetric(envelope *events.Envelope) {
 	c.metricPoints[key] = mVal
 }
 
-func (c *Client) PostMetrics() error {
+func (c *Client) addEvent(envelope *events.Envelope) {
+	title := fmt.Sprintf("%s: %d", envelope.GetError().GetSource(), envelope.GetError().GetCode())
+	event := Event{
+		Title:        title,
+		Text:         envelope.GetError().GetMessage(),
+		DateHappened: envelope.GetTimestamp() / int64(time.Second),
+		Tags:         parseTags(envelope),
+	}
+
+	c.events = append(c.events, event)
+}
+
+func (c *Client) Post() error {
 	c.populateInternalMetrics()
+
+	if err := c.postMetrics(); err != nil {
+		return err
+	}
+
+	if err := c.postEvents(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) postMetrics() error {
 	numMetrics := len(c.metricPoints)
 	c.log.Infof("Posting %d metrics", numMetrics)
 
 	c.totalMetricsSent += uint64(len(c.metricPoints))
-	seriesBytes := c.formatter.Format(c.prefix, c.maxPostBytes, c.metricPoints)
+	seriesBytes := c.formatter.FormatMetrics(c.prefix, c.maxPostBytes, c.metricPoints)
 	c.metricPoints = make(map[MetricKey]MetricValue)
 
-	for _, data := range seriesBytes {
-		if uint32(len(data)) > c.maxPostBytes {
-			c.log.Infof("Throwing out metric that exceeds %d bytes", c.maxPostBytes)
-			continue
-		}
+	return c.sendData(seriesBytes, c.seriesURL())
+}
 
-		if err := c.postMetrics(data); err != nil {
+func (c *Client) postEvents() error {
+	numEvents := len(c.events)
+	c.log.Infof("Posting %d events", numEvents)
+
+	c.totalMetricsSent += uint64(numEvents)
+	for _, event := range c.events {
+
+		eventBytes := c.formatter.FormatEvent(c.prefix, c.maxPostBytes, event)
+		c.events = make([]Event, 0)
+
+		if err := c.sendData(eventBytes, c.eventsURL()); err != nil {
 			return err
 		}
 	}
@@ -148,9 +201,23 @@ func (c *Client) PostMetrics() error {
 	return nil
 }
 
-func (c *Client) postMetrics(seriesBytes []byte) error {
-	url := c.seriesURL()
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(seriesBytes))
+func (c *Client) sendData(data [][]byte, url string) error {
+	for _, chunk := range data {
+		if uint32(len(chunk)) > c.maxPostBytes {
+			c.log.Infof("Throwing out data chunk that exceeds %d bytes", c.maxPostBytes)
+			continue
+		}
+
+		if err := c.send(chunk, url); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) send(data []byte, url string) error {
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -170,7 +237,12 @@ func (c *Client) postMetrics(seriesBytes []byte) error {
 }
 
 func (c *Client) seriesURL() string {
-	url := fmt.Sprintf("%s?api_key=%s", c.apiURL, c.apiKey)
+	url := fmt.Sprintf("%s/series?api_key=%s", c.apiURL, c.apiKey)
+	return url
+}
+
+func (c *Client) eventsURL() string {
+	url := fmt.Sprintf("%s/events?api_key=%s", c.apiURL, c.apiKey)
 	return url
 }
 

--- a/datadogclient/datadog_client_test.go
+++ b/datadogclient/datadog_client_test.go
@@ -67,7 +67,7 @@ var _ = Describe("DatadogClient", func() {
 		})
 
 		It("respects the timeout", func() {
-			c.AddMetric(&events.Envelope{
+			c.Add(&events.Envelope{
 				Origin:    proto.String("test-origin"),
 				Timestamp: proto.Int64(1000000000),
 				EventType: events.Envelope_ValueMetric.Enum(),
@@ -81,14 +81,14 @@ var _ = Describe("DatadogClient", func() {
 
 			errs := make(chan error)
 			go func() {
-				errs <- c.PostMetrics()
+				errs <- c.Post()
 			}()
 			Eventually(errs).Should(Receive(HaveOccurred()))
 		})
 	})
 
 	It("sets Content-Type header when making POST requests", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("test-origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -100,7 +100,7 @@ var _ = Describe("DatadogClient", func() {
 			Ip:         proto.String("10.0.1.2"),
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 		var req *http.Request
 		Eventually(reqs).Should(Receive(&req))
@@ -109,7 +109,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("sends tags", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("test-origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -127,7 +127,7 @@ var _ = Describe("DatadogClient", func() {
 			},
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -149,7 +149,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("uses tags as an identifier for batching purposes", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("test-origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -167,7 +167,7 @@ var _ = Describe("DatadogClient", func() {
 			},
 		})
 
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("test-origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -185,7 +185,7 @@ var _ = Describe("DatadogClient", func() {
 			},
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -214,7 +214,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("ignores messages that aren't value metrics or counter events", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_LogMessage.Enum(),
@@ -227,7 +227,7 @@ var _ = Describe("DatadogClient", func() {
 			Job:        proto.String("doppler"),
 		})
 
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ContainerMetric.Enum(),
@@ -242,7 +242,7 @@ var _ = Describe("DatadogClient", func() {
 			Job:        proto.String("doppler"),
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -255,7 +255,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("generates aggregate messages even when idle", func() {
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -266,7 +266,7 @@ var _ = Describe("DatadogClient", func() {
 
 		validateMetrics(payload, 0, 0)
 
-		err = c.PostMetrics()
+		err = c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(2))
@@ -278,7 +278,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("posts ValueMetrics in JSON format", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -290,7 +290,7 @@ var _ = Describe("DatadogClient", func() {
 			Job:        proto.String("doppler"),
 		})
 
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(2000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -302,7 +302,7 @@ var _ = Describe("DatadogClient", func() {
 			Job:        proto.String("doppler"),
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -336,9 +336,40 @@ var _ = Describe("DatadogClient", func() {
 		validateMetrics(payload, 2, 0)
 	})
 
+	It("posts Error Event in JSON format", func() {
+		c.Add(&events.Envelope{
+			Origin:    proto.String("origin"),
+			Timestamp: proto.Int64(1000000000),
+			EventType: events.Envelope_Error.Enum(),
+			Error: &events.Error{
+				Source:  proto.String("app"),
+				Message: proto.String("application failure"),
+				Code:    proto.Int32(500),
+			},
+			Deployment: proto.String("deployment-name"),
+			Job:        proto.String("doppler"),
+		})
+
+		err := c.Post()
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(bodies).Should(HaveLen(2))
+
+		eventsFound := false
+		var event datadogclient.Event
+		err = json.Unmarshal(bodies[1], &event)
+		Expect(err).NotTo(HaveOccurred())
+
+		eventsFound = true
+		Expect(event.Title).To(Equal("app: 500"))
+		Expect(event.Text).To(Equal("application failure"))
+		Expect(event.Tags).To(Equal([]string{"deployment:deployment-name", "job:doppler"}))
+		Expect(eventsFound).To(BeTrue())
+	})
+
 	It("breaks up a message that exceeds the FlushMaxBytes", func() {
 		for i := 0; i < 1000; i++ {
-			c.AddMetric(&events.Envelope{
+			c.Add(&events.Envelope{
 				Origin:    proto.String("origin"),
 				Timestamp: proto.Int64(1000000000 + int64(i)),
 				EventType: events.Envelope_ValueMetric.Enum(),
@@ -351,7 +382,7 @@ var _ = Describe("DatadogClient", func() {
 			})
 		}
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		f := func() int {
@@ -362,7 +393,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("discards metrics that exceed that max size", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -374,7 +405,7 @@ var _ = Describe("DatadogClient", func() {
 			Job:        proto.String("doppler"),
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		f := func() int {
@@ -385,7 +416,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("registers metrics with the same name but different tags as different", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -397,7 +428,7 @@ var _ = Describe("DatadogClient", func() {
 			Job:        proto.String("doppler"),
 		})
 
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(2000000000),
 			EventType: events.Envelope_ValueMetric.Enum(),
@@ -409,7 +440,7 @@ var _ = Describe("DatadogClient", func() {
 			Job:        proto.String("gorouter"),
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -453,7 +484,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("posts CounterEvents in JSON format and empties map after post", func() {
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(1000000000),
 			EventType: events.Envelope_CounterEvent.Enum(),
@@ -464,7 +495,7 @@ var _ = Describe("DatadogClient", func() {
 			},
 		})
 
-		c.AddMetric(&events.Envelope{
+		c.Add(&events.Envelope{
 			Origin:    proto.String("origin"),
 			Timestamp: proto.Int64(2000000000),
 			EventType: events.Envelope_CounterEvent.Enum(),
@@ -475,7 +506,7 @@ var _ = Describe("DatadogClient", func() {
 			},
 		})
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -505,7 +536,7 @@ var _ = Describe("DatadogClient", func() {
 		Expect(counterNameFound).To(BeTrue())
 		validateMetrics(payload, 2, 0)
 
-		err = c.PostMetrics()
+		err = c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(2))
@@ -520,7 +551,7 @@ var _ = Describe("DatadogClient", func() {
 	It("sends a value 1 for the slowConsumerAlert metric when consumer error is set", func() {
 		c.AlertSlowConsumerError()
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -537,7 +568,7 @@ var _ = Describe("DatadogClient", func() {
 	})
 
 	It("sends a value 0 for the slowConsumerAlert metric when consumer error is not set", func() {
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -556,7 +587,7 @@ var _ = Describe("DatadogClient", func() {
 	It("unsets the slow consumer error once it publishes the alert to datadog", func() {
 		c.AlertSlowConsumerError()
 
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(1))
@@ -568,7 +599,7 @@ var _ = Describe("DatadogClient", func() {
 		Expect(errMetric).NotTo(BeNil())
 		Expect(errMetric.Points[0].Value).To(BeEquivalentTo(1))
 
-		err = c.PostMetrics()
+		err = c.Post()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(bodies).Should(HaveLen(2))
@@ -583,18 +614,18 @@ var _ = Describe("DatadogClient", func() {
 	It("returns an error when datadog responds with a non 200 response code", func() {
 		responseCode = http.StatusBadRequest // 400
 		responseBody = []byte("something went horribly wrong")
-		err := c.PostMetrics()
+		err := c.Post()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("datadog request returned HTTP response: 400 Bad Request"))
 		Expect(err.Error()).To(ContainSubstring("something went horribly wrong"))
 
 		responseCode = http.StatusSwitchingProtocols // 101
-		err = c.PostMetrics()
+		err = c.Post()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("datadog request returned HTTP response: 101"))
 
 		responseCode = http.StatusAccepted // 201
-		err = c.PostMetrics()
+		err = c.Post()
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/datadogclient/formatter.go
+++ b/datadogclient/formatter.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 type Formatter struct{}
 
-func (f Formatter) Format(prefix string, maxPostBytes uint32, data map[MetricKey]MetricValue) [][]byte {
+func (f Formatter) FormatMetrics(prefix string, maxPostBytes uint32, data map[MetricKey]MetricValue) [][]byte {
 	if len(data) == 0 {
 		return nil
 	}
@@ -13,14 +13,20 @@ func (f Formatter) Format(prefix string, maxPostBytes uint32, data map[MetricKey
 	seriesBytes := formatMetrics(prefix, data)
 	if uint32(len(seriesBytes)) > maxPostBytes && canSplit(data) {
 		metricsA, metricsB := splitPoints(data)
-		result = append(result, f.Format(prefix, maxPostBytes, metricsA)...)
-		result = append(result, f.Format(prefix, maxPostBytes, metricsB)...)
+		result = append(result, f.FormatMetrics(prefix, maxPostBytes, metricsA)...)
+		result = append(result, f.FormatMetrics(prefix, maxPostBytes, metricsB)...)
 
 		return result
 	}
 
 	result = append(result, seriesBytes)
 	return result
+}
+
+func (f Formatter) FormatEvent(prefix string, maxPostBytes uint32, event Event) [][]byte {
+	var result [][]byte
+	eventsBytes, _ := json.Marshal(event)
+	return append(result, eventsBytes)
 }
 
 func formatMetrics(prefix string, data map[MetricKey]MetricValue) []byte {

--- a/datadogclient/formatter_test.go
+++ b/datadogclient/formatter_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Formatter", func() {
 	})
 
 	It("does not return empty data", func() {
-		result := formatter.Format("some-prefix", 1024, nil)
+		result := formatter.FormatMetrics("some-prefix", 1024, nil)
 		Expect(result).To(HaveLen(0))
 	})
 
@@ -28,7 +28,7 @@ var _ = Describe("Formatter", func() {
 				Value: 9,
 			}},
 		}
-		result := formatter.Format("some-prefix", 1, m)
+		result := formatter.FormatMetrics("some-prefix", 1, m)
 
 		Expect(result).To(HaveLen(1))
 	})

--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -90,7 +90,7 @@ func (d *DatadogFirehoseNozzle) postToDatadog() error {
 			}
 
 			d.handleMessage(envelope)
-			d.client.AddMetric(envelope)
+			d.client.Add(envelope)
 		case err := <-d.errs:
 			d.handleError(err)
 			return err
@@ -99,7 +99,7 @@ func (d *DatadogFirehoseNozzle) postToDatadog() error {
 }
 
 func (d *DatadogFirehoseNozzle) postMetrics() {
-	err := d.client.PostMetrics()
+	err := d.client.Post()
 	if err != nil {
 		d.log.Fatalf("FATAL ERROR: %s\n\n", err)
 	}


### PR DESCRIPTION
Related to https://github.com/cloudfoundry-incubator/datadog-firehose-nozzle-release/pull/8

From: #143312267

Signed-off-by: Roberto Jimenez Sanchez <jszroberto@gmail.com>